### PR TITLE
Remix keycloak integration

### DIFF
--- a/web-insights-app/README.md
+++ b/web-insights-app/README.md
@@ -1,6 +1,15 @@
-# Welcome to Remix!
 
-- [Remix Docs](https://remix.run/docs)
+
+# WebInsights APP layer
+
+## .env file
+First, create an .env file in the root of your project:
+
+```
+COOKIE_SECRET = "cookie secret"
+KEYCLOAK_DOMAIN = "keycloak domain"
+KEYCLOAK_CLIENT_SECRET = "your secret"
+```
 
 ## Development
 
@@ -27,27 +36,3 @@ npm start
 ```
 
 Now you'll need to pick a host to deploy it to.
-
-### DIY
-
-If you're familiar with deploying node applications, the built-in Remix app server is production-ready.
-
-Make sure to deploy the output of `remix build`
-
-- `build/`
-- `public/build/`
-
-### Using a Template
-
-When you ran `npx create-remix@latest` there were a few choices for hosting. You can run that again to create a new project, then copy over your `app/` folder to the new project that's pre-configured for your target server.
-
-```sh
-cd ..
-# create a new project, and pick a pre-configured host
-npx create-remix@latest
-cd my-new-remix-app
-# remove the new project's app (not the old one!)
-rm -rf app
-# copy your app over
-cp -R ../my-old-remix-app/app app
-```

--- a/web-insights-app/app/routes/_index.tsx
+++ b/web-insights-app/app/routes/_index.tsx
@@ -1,4 +1,5 @@
 import type { V2_MetaFunction } from "@remix-run/node";
+import { Form, Link, useLoaderData } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [
@@ -9,33 +10,11 @@ export const meta: V2_MetaFunction = () => {
 
 export default function Index() {
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
-      <h1>Welcome to Remix</h1>
-      <ul>
-        <li>
-          <a
-            target="_blank"
-            href="https://remix.run/tutorials/blog"
-            rel="noreferrer"
-          >
-            15m Quickstart Blog Tutorial
-          </a>
-        </li>
-        <li>
-          <a
-            target="_blank"
-            href="https://remix.run/tutorials/jokes"
-            rel="noreferrer"
-          >
-            Deep Dive Jokes App Tutorial
-          </a>
-        </li>
-        <li>
-          <a target="_blank" href="https://remix.run/docs" rel="noreferrer">
-            Remix Docs
-          </a>
-        </li>
-      </ul>
-    </div>
+    <>
+      <Link to="/dashboard">Dashboard</Link>
+      <Form action="/auth/keycloak" method="post">
+        <button>Login</button>
+      </Form>
+    </>
   );
 }

--- a/web-insights-app/app/routes/_index.tsx
+++ b/web-insights-app/app/routes/_index.tsx
@@ -1,5 +1,5 @@
 import type { V2_MetaFunction } from "@remix-run/node";
-import { Form, Link, useLoaderData } from "@remix-run/react";
+import { Form, Link } from "@remix-run/react";
 
 export const meta: V2_MetaFunction = () => {
   return [

--- a/web-insights-app/app/routes/auth.keycloak.callback.ts
+++ b/web-insights-app/app/routes/auth.keycloak.callback.ts
@@ -1,0 +1,10 @@
+import type { LoaderFunction } from "@remix-run/node";
+
+import { authenticator } from "~/utils/auth";
+
+export const loader: LoaderFunction = ({ request }) => {
+  return authenticator.authenticate("keycloak", request, {
+    successRedirect: "/dashboard",
+    failureRedirect: "/login",
+  });
+};

--- a/web-insights-app/app/routes/auth.keycloak.logout.ts
+++ b/web-insights-app/app/routes/auth.keycloak.logout.ts
@@ -1,7 +1,7 @@
 import type { LoaderFunction } from "@remix-run/node";
 import { authenticator, generateLogoutUrl } from "~/utils/auth";
 
-export const loader: LoaderFunction = async ({ request, context }) => {
+export const loader: LoaderFunction = async ({ request }) => {
   await authenticator.logout(request, {
     redirectTo: generateLogoutUrl(),
   });

--- a/web-insights-app/app/routes/auth.keycloak.logout.ts
+++ b/web-insights-app/app/routes/auth.keycloak.logout.ts
@@ -1,0 +1,8 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { authenticator, generateLogoutUrl } from "~/utils/auth";
+
+export const loader: LoaderFunction = async ({ request, context }) => {
+  await authenticator.logout(request, {
+    redirectTo: generateLogoutUrl(),
+  });
+};

--- a/web-insights-app/app/routes/auth.keycloak.tsx
+++ b/web-insights-app/app/routes/auth.keycloak.tsx
@@ -1,0 +1,10 @@
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
+import { authenticator } from "~/utils/auth";
+
+export const loader: LoaderFunction = () => redirect("/dashboard");
+
+export const action: ActionFunction = ({ request }) => {
+  return authenticator.authenticate("keycloak", request);
+};

--- a/web-insights-app/app/routes/dashboard.tsx
+++ b/web-insights-app/app/routes/dashboard.tsx
@@ -1,0 +1,19 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { Form, Link } from "@remix-run/react";
+import { isAuthenticated } from "~/utils/auth";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  return await isAuthenticated(request);
+};
+
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>dashboard</h1>
+      <Form action="/auth/keycloak/logout">
+        <button>Logout</button>
+      </Form>
+      <Link to="/">Go to home page</Link>
+    </div>
+  );
+}

--- a/web-insights-app/app/utils/auth/auth.server.ts
+++ b/web-insights-app/app/utils/auth/auth.server.ts
@@ -1,0 +1,37 @@
+import { Authenticator } from "remix-auth";
+import { KeycloakStrategy } from "remix-auth-keycloak";
+import { createCookieSessionStorage } from "@remix-run/node";
+import { isProductionEnv } from "~/utils/isProductionEnv";
+
+export const sessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: "_session",
+    sameSite: "lax",
+    path: "/",
+    httpOnly: true,
+    secrets: [process.env.COOKIE_SECRET],
+    secure: isProductionEnv(),
+  },
+});
+
+export type User = {
+  name: string;
+};
+
+export const authenticator = new Authenticator<User>(sessionStorage);
+
+const keycloakStrategy = new KeycloakStrategy(
+  {
+    useSSL: isProductionEnv(),
+    domain: process.env.KEYCLOAK_DOMAIN,
+    realm: "WebInsights",
+    clientID: "insider",
+    clientSecret: process.env.KEYCLOAK_CLIENT_SECRET,
+    callbackURL: "/auth/keycloak/callback",
+  },
+  async ({ profile }) => {
+    return { name: profile.displayName };
+  },
+);
+
+authenticator.use(keycloakStrategy);

--- a/web-insights-app/app/utils/auth/generateLogoutUrl.ts
+++ b/web-insights-app/app/utils/auth/generateLogoutUrl.ts
@@ -1,0 +1,7 @@
+import { isProductionEnv } from "~/utils/isProductionEnv";
+
+export function generateLogoutUrl() {
+  return `${isProductionEnv() ? "https" : "http"}://${
+    process.env.KEYCLOAK_DOMAIN
+  }/realms/WebInsights/protocol/openid-connect/logout`;
+}

--- a/web-insights-app/app/utils/auth/index.ts
+++ b/web-insights-app/app/utils/auth/index.ts
@@ -1,0 +1,3 @@
+export { authenticator, sessionStorage } from "./auth.server";
+export { generateLogoutUrl } from "./generateLogoutUrl";
+export { isAuthenticated } from "./isAuthenticated";

--- a/web-insights-app/app/utils/auth/isAuthenticated.ts
+++ b/web-insights-app/app/utils/auth/isAuthenticated.ts
@@ -1,0 +1,8 @@
+import type { Session } from "@remix-run/server-runtime";
+import { authenticator } from "~/utils/auth/auth.server";
+
+export async function isAuthenticated(request: Request | Session) {
+  return await authenticator.isAuthenticated(request, {
+    failureRedirect: "/",
+  });
+}

--- a/web-insights-app/app/utils/isProductionEnv.ts
+++ b/web-insights-app/app/utils/isProductionEnv.ts
@@ -1,0 +1,3 @@
+export function isProductionEnv() {
+  return process.env.NODE_ENV === "production";
+}

--- a/web-insights-app/environment.d.ts
+++ b/web-insights-app/environment.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      COOKIE_SECRET: string;
+      KEYCLOAK_DOMAIN: string;
+      KEYCLOAK_CLIENT_SECRET: string;
+    }
+  }
+}
+
+export {};

--- a/web-insights-app/package-lock.json
+++ b/web-insights-app/package-lock.json
@@ -10,11 +10,13 @@
         "@remix-run/react": "^1.18.1",
         "@remix-run/serve": "^1.18.1",
         "@storybook/addon-a11y": "^7.0.25",
+        "@types/node": "^20.10.0",
         "clsx": "^2.0.0",
         "isbot": "^3.6.8",
         "normalize.css": "^8.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "remix-auth-keycloak": "^1.2.0",
         "tailwind-merge": "^1.14.0"
       },
       "devDependencies": {
@@ -6708,9 +6710,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
-      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.4",
@@ -9145,7 +9150,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -16668,8 +16672,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -18860,6 +18863,50 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remix-auth": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/remix-auth/-/remix-auth-3.6.0.tgz",
+      "integrity": "sha512-mxlzLYi+/GKQSaXIqIw15dxAT1wm+93REAeDIft2unrKDYnjaGhhpapyPhdbALln86wt9lNAk21znfRss3fG7Q==",
+      "dependencies": {
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@remix-run/react": "^1.0.0 || ^2.0.0",
+        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/remix-auth-keycloak": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remix-auth-keycloak/-/remix-auth-keycloak-1.2.0.tgz",
+      "integrity": "sha512-zmv0EZbIejmZBW+456gheo0e8kIKGn2aUahNDZOgtwqGwbswHTmkAfCvzxXW5OkwEXF5PxAlE6igBu5yNYUWug==",
+      "dependencies": {
+        "remix-auth": "^3.2.2",
+        "remix-auth-oauth2": "^1.2.2"
+      },
+      "peerDependencies": {
+        "@remix-run/server-runtime": "^1.0.0"
+      }
+    },
+    "node_modules/remix-auth-oauth2": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/remix-auth-oauth2/-/remix-auth-oauth2-1.11.0.tgz",
+      "integrity": "sha512-Yf1LF6NLYPFa7X2Rax/VEhXmYXFjZOi/q+7DmbMeoMHjAfkpqxbvzqqYSKIKDGR51z5TXR5na4to4380mir5bg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0",
+        "remix-auth": "^3.6.0"
+      }
+    },
+    "node_modules/remix-auth/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -20968,6 +21015,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unfetch": {
       "version": "4.2.0",

--- a/web-insights-app/package.json
+++ b/web-insights-app/package.json
@@ -23,11 +23,13 @@
     "@remix-run/react": "^1.18.1",
     "@remix-run/serve": "^1.18.1",
     "@storybook/addon-a11y": "^7.0.25",
+    "@types/node": "^20.10.0",
     "clsx": "^2.0.0",
     "isbot": "^3.6.8",
     "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "remix-auth-keycloak": "^1.2.0",
     "tailwind-merge": "^1.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why
Add Remix keycloak integration
# What
- Setup `WebInsights` realm for auth2 integration
- Use `remix-auth-keycloak` package for basic auth2 integration