### PR TITLE
refactor: move keycloak provides into auth folder

### DIFF
--- a/web-insights-web/src/app/app.config.ts
+++ b/web-insights-web/src/app/app.config.ts
@@ -1,66 +1,20 @@
-import {
-  APP_INITIALIZER,
-  ApplicationConfig,
-  provideZoneChangeDetection,
-  Provider,
-} from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { KeycloakBearerInterceptor, KeycloakService } from 'keycloak-angular';
 import {
-  HTTP_INTERCEPTORS,
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
+import { providers } from './auth/auth-providers';
 import { environment } from '../environments/environment';
-import {
-  ENV_CONFIG,
-  EnvironmentConfig,
-} from '../environments/environment-config.token';
+import { ENV_CONFIG } from '../environments/environment-config.token';
 import { routes } from './app.routes';
-
-function initializeKeycloak(
-  keycloak: KeycloakService,
-  config: EnvironmentConfig
-) {
-  return () =>
-    keycloak.init({
-      config: {
-        url: config.keycloak.url,
-        realm: config.keycloak.realm,
-        clientId: config.keycloak.clientId,
-      },
-      initOptions: {
-        onLoad: 'check-sso',
-        silentCheckSsoRedirectUri:
-          window.location.origin + '/assets/silent-check-sso.html', // URI for silent SSO checks
-      },
-      enableBearerInterceptor: true,
-      bearerPrefix: 'Bearer',
-      bearerExcludedUrls: ['/assets', '/clients/public'],
-    });
-}
-
-const KeycloakBearerInterceptorProvider: Provider = {
-  provide: HTTP_INTERCEPTORS,
-  useClass: KeycloakBearerInterceptor,
-  multi: true,
-};
-
-const KeycloakInitializerProvider: Provider = {
-  provide: APP_INITIALIZER,
-  useFactory: initializeKeycloak,
-  multi: true,
-  deps: [KeycloakService, ENV_CONFIG],
-};
 
 export const appConfig: ApplicationConfig = {
   providers: [
     { provide: ENV_CONFIG, useValue: environment },
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideHttpClient(withInterceptorsFromDi()),
-    KeycloakInitializerProvider,
-    KeycloakBearerInterceptorProvider,
-    KeycloakService,
+    ...providers,
     provideRouter(routes),
   ],
 };

--- a/web-insights-web/src/app/auth/auth-providers.ts
+++ b/web-insights-web/src/app/auth/auth-providers.ts
@@ -1,0 +1,24 @@
+import { APP_INITIALIZER, Provider } from '@angular/core';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { KeycloakBearerInterceptor, KeycloakService } from 'keycloak-angular';
+import { ENV_CONFIG } from 'src/environments/environment-config.token';
+import { initializeKeycloak } from './initialize-keycloak';
+
+const KeycloakBearerInterceptorProvider: Provider = {
+  provide: HTTP_INTERCEPTORS,
+  useClass: KeycloakBearerInterceptor,
+  multi: true,
+};
+
+const KeycloakInitializerProvider: Provider = {
+  provide: APP_INITIALIZER,
+  useFactory: initializeKeycloak,
+  multi: true,
+  deps: [KeycloakService, ENV_CONFIG],
+};
+
+export const providers: Provider[] = [
+  KeycloakInitializerProvider,
+  KeycloakBearerInterceptorProvider,
+  KeycloakService,
+];

--- a/web-insights-web/src/app/auth/initialize-keycloak.spec.ts
+++ b/web-insights-web/src/app/auth/initialize-keycloak.spec.ts
@@ -1,0 +1,34 @@
+import { KeycloakService } from 'keycloak-angular';
+import { environment } from 'src/environments/environment';
+import { initializeKeycloak } from './initialize-keycloak';
+
+describe('initializeKeycloak', () => {
+  let keycloakServiceSpy: jasmine.SpyObj<KeycloakService>;
+
+  beforeEach(() => {
+    keycloakServiceSpy = jasmine.createSpyObj('KeycloakService', ['init']);
+  });
+
+  it('should call initialize keycloak correctly ', () => {
+    const initKeycloak = initializeKeycloak(keycloakServiceSpy, environment);
+
+    initKeycloak();
+
+    expect(keycloakServiceSpy.init).toHaveBeenCalledOnceWith({
+      config: {
+        url: environment.keycloak.url,
+        realm: environment.keycloak.realm,
+        clientId: environment.keycloak.clientId,
+      },
+      loadUserProfileAtStartUp: true,
+      initOptions: {
+        onLoad: 'check-sso',
+        silentCheckSsoRedirectUri:
+          window.location.origin + '/assets/silent-check-sso.html',
+      },
+      enableBearerInterceptor: true,
+      bearerPrefix: 'Bearer',
+      bearerExcludedUrls: ['/assets', '/clients/public'],
+    });
+  });
+});

--- a/web-insights-web/src/app/auth/initialize-keycloak.ts
+++ b/web-insights-web/src/app/auth/initialize-keycloak.ts
@@ -1,0 +1,25 @@
+import { KeycloakService } from 'keycloak-angular';
+import { EnvironmentConfig } from '../../environments/environment-config.token';
+
+export function initializeKeycloak(
+  keycloak: KeycloakService,
+  config: EnvironmentConfig
+) {
+  return () =>
+    keycloak.init({
+      config: {
+        url: config.keycloak.url,
+        realm: config.keycloak.realm,
+        clientId: config.keycloak.clientId,
+      },
+      loadUserProfileAtStartUp: true,
+      initOptions: {
+        onLoad: 'check-sso',
+        silentCheckSsoRedirectUri:
+          window.location.origin + '/assets/silent-check-sso.html',
+      },
+      enableBearerInterceptor: true,
+      bearerPrefix: 'Bearer',
+      bearerExcludedUrls: ['/assets', '/clients/public'],
+    });
+}

--- a/web-insights-web/tsconfig.json
+++ b/web-insights-web/tsconfig.json
@@ -3,6 +3,10 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@app/*": ["src/app/*"],
+    },
     "outDir": "./dist/out-tsc",
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
# Why ?
Refactor how we initialize integration with keycloak

# What
Move providers into `auth` folder. In this folder i will create `AuthService`.