### PR TITLE
feat: remove h1 tah from app.component.html

### DIFF
--- a/web-insights-web/src/app/app.component.html
+++ b/web-insights-web/src/app/app.component.html
@@ -1,3 +1,1 @@
-<h1 class="text-3xl font-bold underline">WebInsights</h1>
-
 <router-outlet />

--- a/web-insights-web/src/app/app.component.spec.ts
+++ b/web-insights-web/src/app/app.component.spec.ts
@@ -19,11 +19,4 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app.title).toEqual('WebInsights');
   });
-
-  it('should render correct h1', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('WebInsights');
-  });
 });

--- a/web-insights-web/src/app/app.component.ts
+++ b/web-insights-web/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { RouterOutlet } from '@angular/router';
 @Component({
   selector: 'wi-app-root',
   imports: [RouterOutlet],
-  templateUrl: './app.component.html',
+  template: `<router-outlet />`,
   styleUrl: './app.component.css',
   standalone: true,
 })


### PR DESCRIPTION
# Why ?
User is able to see h1 title before redirecting to the login page.

# What ?
Remove h1 tag from app component template