### PR TITLE
feat: import and export realm with user

### DIFF
--- a/scripts/keycloak/export-realm.sh
+++ b/scripts/keycloak/export-realm.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source ./keycloak-config.sh
+
+EXPORT_PATH="/opt/keycloak/data/realm-export"
+
+docker exec -it $CONTAINER_NAME /opt/keycloak/bin/kc.sh export --realm "WebInsights" --dir $EXPORT_PATH
+docker cp $CONTAINER_NAME:$EXPORT_PATH/. $KEYCLOAK_IMPORTS_FOLDER
+
+if [ $? -eq 0 ]; then
+  echo "Realm exported to $KEYCLOAK_IMPORTS_FOLDER."
+else
+  echo "Failed to export realm to $KEYCLOAK_IMPORTS_FOLDER."
+fi

--- a/scripts/keycloak/import-realm.sh
+++ b/scripts/keycloak/import-realm.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source ./keycloak-config.sh
+
+IMPORT_PATH="/opt/keycloak/data/import"
+
+docker cp $KEYCLOAK_IMPORTS_FOLDER/. $CONTAINER_NAME:$IMPORT_PATH
+docker exec -it $CONTAINER_NAME /opt/keycloak/bin/kc.sh import --dir $IMPORT_PATH
+
+if [ $? -eq 0 ]; then
+  echo "Realm exported to $KEYCLOAK_IMPORTS_FOLDER."
+else
+  echo "Failed to export realm to $KEYCLOAK_IMPORTS_FOLDER."
+fi

--- a/scripts/keycloak/keycloak-config.sh
+++ b/scripts/keycloak/keycloak-config.sh
@@ -1,0 +1,2 @@
+CONTAINER_NAME="web-insights-keycloak"
+KEYCLOAK_IMPORTS_FOLDER="../../web-insights-docker/keycloak/imports"

--- a/web-insights-docker/docker-compose.yml
+++ b/web-insights-docker/docker-compose.yml
@@ -1,6 +1,3 @@
-version: '3.1'
-
-
 volumes:
   web-insights-database:
     driver: local
@@ -18,8 +15,10 @@ services:
     ports:
       - "5432:5432"
   web-insights-keycloak:
-    command: start-dev
+    command: start-dev --import-realm
     container_name: web-insights-keycloak
+    volumes:
+      - ./keycloak/imports:/opt/keycloak/data/import
     environment:
       KEYCLOAK_ADMIN: keycloak_admin
       KEYCLOAK_ADMIN_PASSWORD: Pa55w0rd

--- a/web-insights-docker/keycloak/imports/WebInsights-realm.json
+++ b/web-insights-docker/keycloak/imports/WebInsights-realm.json
@@ -1,0 +1,1875 @@
+{
+  "id" : "WebInsights",
+  "realm" : "WebInsights",
+  "notBefore" : 1702408434,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 864000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "f48d9f76-d1ff-42e0-bc94-919640feb818",
+      "name" : "user",
+      "description" : "User role",
+      "composite" : true,
+      "composites" : {
+        "client" : {
+          "insider" : [ "client_user" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "WebInsights",
+      "attributes" : { }
+    }, {
+      "id" : "6ae1c747-baa5-49f5-a8ce-8dce75e365af",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "WebInsights",
+      "attributes" : { }
+    }, {
+      "id" : "625eb07c-daf9-4644-aab5-ac3067fa6c19",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "WebInsights",
+      "attributes" : { }
+    }, {
+      "id" : "80ebc4d2-2c00-402a-91ab-891dacd61d08",
+      "name" : "default-roles-webinsights",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "WebInsights",
+      "attributes" : { }
+    }, {
+      "id" : "57f9e197-74ab-4229-8012-fae387d29828",
+      "name" : "admin",
+      "description" : "Admin role",
+      "composite" : true,
+      "composites" : {
+        "client" : {
+          "insider" : [ "client_admin" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "WebInsights",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "6085b3f1-8b01-4ead-a0d6-8a83765d03f0",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "view-clients", "view-realm", "query-clients", "view-users", "query-users", "query-realms", "view-events", "query-groups", "view-identity-providers", "manage-realm", "manage-users", "manage-authorization", "manage-identity-providers", "manage-events", "impersonation", "manage-clients", "view-authorization", "create-client" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "430f5746-e860-4a85-8cd3-098ace8c609e",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "19832221-be5d-4e04-a618-580bab8ffeed",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "baf1493a-f676-4389-b168-b48fc18a92f2",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "36af4281-5a7a-4542-8750-4fe7320bd7b4",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "d2a2fe5e-ca9a-4943-91ad-c7afb4ff0b42",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "6ce3761c-7e50-46d5-9037-a8b3b2c60d7e",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "0a9068c6-6976-4669-97a3-c07e769e8341",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "3af9b48e-749c-4bd7-8e21-075f7500e93e",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "51a5683c-e256-4084-979d-9aa2bb631ac0",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "a178d5a2-82a2-48b0-9071-9d11d1e7c58e",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "f7305453-5f30-4153-8121-707109f70113",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "27325e42-bc0b-49f3-877d-42dbd5749208",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "0110851d-d780-4256-a20e-9b988c6e9c05",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "b3247186-970b-4187-9fb2-00468aceca4d",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "6e16947d-c130-4b5d-b321-03ed5570bef7",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "a9590b5f-ab79-4660-ad25-427ac8ba8fa7",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "6f3f63d6-420a-41c3-9a41-4025a75d839d",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      }, {
+        "id" : "52a0c4e3-bd71-4afe-a02d-bc495ed6397a",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "be3f7067-0368-4ce6-8cac-4563245d39e7",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "92c04b30-b72d-41ce-8e95-c8de4012de81",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "5d7c1602-2660-4e2d-a4df-2e72dffb740c",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      }, {
+        "id" : "740f5fc1-391e-472f-9480-47da655f39c6",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      }, {
+        "id" : "59d6f62b-ff97-449a-81eb-c1fdc42b6a8f",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      }, {
+        "id" : "ddf96b21-2781-40f2-952e-fe601d6bd72a",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      }, {
+        "id" : "009340cc-08c8-4055-a758-18a59a81b71e",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      }, {
+        "id" : "b8fc872a-c178-408c-93d4-8a02880be07a",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      }, {
+        "id" : "7cbf6707-d378-4484-829e-2c55f5f8f64d",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      }, {
+        "id" : "86a215e2-9a85-4e80-aa0f-6457e2ce2274",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+        "attributes" : { }
+      } ],
+      "insider" : [ {
+        "id" : "03f75166-fe59-4603-80a6-18952ecfd08a",
+        "name" : "client_user",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a8e56061-509a-4a76-bc4b-1f5b91a6d5d4",
+        "attributes" : { }
+      }, {
+        "id" : "73b8b760-ce39-426e-8fd4-f881e2f79480",
+        "name" : "client_admin",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a8e56061-509a-4a76-bc4b-1f5b91a6d5d4",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "80ebc4d2-2c00-402a-91ab-891dacd61d08",
+    "name" : "default-roles-webinsights",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "WebInsights"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "96f3d50b-144e-4338-8ec6-98547e88e6cb",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/WebInsights/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/WebInsights/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "1d8ae971-b02e-4abf-9c07-07046f6d7f23",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/WebInsights/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/WebInsights/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "57e03a5b-9a64-49fd-80be-8951e126594a",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "5c6e5a60-73e5-4b09-8b7f-67708674d805",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "92c04b30-b72d-41ce-8e95-c8de4012de81",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "a8e56061-509a-4a76-bc4b-1f5b91a6d5d4",
+    "clientId" : "insider",
+    "name" : "insider",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "*" ],
+    "webOrigins" : [ "*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "saml.multivalued.roles" : "false",
+      "saml.force.post.binding" : "false",
+      "frontchannel.logout.session.required" : "false",
+      "post.logout.redirect.uris" : "*",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "saml.client.signature" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.allow.ecp.flow" : "false",
+      "saml.assertion.signature" : "false",
+      "id.token.as.detached.signature" : "false",
+      "client.secret.creation.time" : "1707946259",
+      "saml.encrypt" : "false",
+      "login_theme" : "keycloak",
+      "saml.server.signature" : "false",
+      "exclude.session.state.from.auth.response" : "true",
+      "saml.artifact.binding" : "false",
+      "saml_force_name_id_format" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "acr.loa.map" : "{}",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "token.response.type.bearer.lower-case" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "e1427980-3d75-4231-97fd-8e597c9838ff",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "48a122bc-b635-4bee-85fb-1cd687f225e2",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6f360547-eed8-4841-8841-1e3e78089ea2",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientId",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientId",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "8903d2fe-7f44-4f31-a278-88e39fcadaf4",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "720aad32-efbe-45f0-bd7f-05a341e1b29d",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/WebInsights/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/WebInsights/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "62209480-457a-4683-97f8-bf8d758940c8",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "7ffcc32c-a110-4123-a29a-9e1cf8cf15a2",
+    "name" : "insider",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "ba7792e1-cd6b-47c6-9968-4b834e450813",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "2d566cc5-6c8e-4875-93dd-5c8cc1538c11",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "143701cd-dd26-470c-8282-279d56a38f04",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "6c0c673c-8694-452b-bf73-a863395872ca",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "5bf0664f-14cb-4483-9ee4-ede72bf25491",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "c938620c-5dfc-41ea-84de-02342c008d68",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "dcfc0512-cc36-4494-81c9-ad58958030f2",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "c8466653-a180-46ac-a4f9-ddbd6e08751d",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "5202859b-c4b4-4fd8-b88b-74e8e5ca0f0e",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "0565e9a3-5967-40a2-b37c-41a4b712343b",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "fe4d9929-e987-470d-94a6-e5f7597b923d",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "4a7be475-c91e-478c-9275-cc3f6a7c0af9",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "8177ae43-34c2-46e9-909e-80c4d0650d90",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "c401c7ea-f49c-4fb0-93d4-1e7610d481b6",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "f319d331-e6b8-4c2d-afec-c395393aa31f",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "5364f97c-300e-4277-8ce8-c5b9a18e4986",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "c2e771c6-82ef-4dac-9fa5-651e8bda3bb2",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6c53ff10-85f7-4cf8-ba3e-681f41e986d1",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "979c4b90-f236-4396-9c67-760dd26682d3",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "40426886-c89c-44ac-ac6d-c8cb9211b642",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "a9e654bb-8abf-4632-b538-80fa9d5c64f9",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "21c11cd2-7653-4a1b-ae4b-5cce2199cbce",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "ee0063b7-4cf0-41d1-b0dc-4a576c4b2a8d",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "7ef02426-308b-4d03-bc9e-e22f7bd8fc00",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "bc98c186-22cf-4235-b261-95998a0e0360",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "799b6c61-08c2-4476-9bc4-c522760fc66a",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "031af658-343e-4416-aabf-298be726dc4e",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b7ba512c-04fc-475b-a31f-68ee79b41ba9",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f3e58724-501a-43bf-81ff-cd251a74ce4a",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "35e6ffda-b266-4461-9faf-ef7e5c6e225d",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ac170648-ce9d-4f5b-a192-e6e6dbc5d3cb",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "67da0709-24c8-4d9e-8a10-56ae14d23891",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c6384a4f-0a49-420a-8dcd-dbc0562e12ed",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e9bc152e-13b1-448b-a4cb-ed31a2f41789",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c242a791-f348-4bfc-ac9d-ae17195e15f5",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fc406852-c686-4e98-a46f-da6b8a679d58",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b796b3df-e2f8-47bb-8562-86f4a57e8c7a",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "loginTheme" : "keycloak",
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "e8f8976d-ad07-4fd2-9e9a-766bc6ba310a",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "4054ab5c-cb02-49b0-9f84-523b222fa2bc",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-address-mapper" ]
+      }
+    }, {
+      "id" : "48879f4e-0b22-4541-ac42-be57db28aa86",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "d304ff17-0b7c-4e75-99cb-b5034f406224",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "cf22ab94-5036-41f8-94a3-5a5aa7d6ca95",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "79799ee1-ddfb-4c55-9f4d-5652518754b9",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
+      }
+    }, {
+      "id" : "37ab638e-4a3b-4722-beef-c9317b7d909a",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "984c7787-2b2d-44cd-98cd-8348081f1dd2",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "3b7695d9-8ec4-4e85-9dde-b059e01fd747",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "4cb7431d-5e77-4f9e-b013-b72b7bc3138e" ],
+        "secret" : [ "qxUFHSD0AbmkNro6PlLmAOmZWmzS_f_m5ma_bfVQk1wwk5r7PSMGfTNfmUgArUZic1wYFXRfmjl-GG1sP2u-yw" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "0c8f6cf0-9ecc-40f9-ad1a-daf8ed29053e",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEApE5YOPkspnnCv5CgSujw5Z3jR+s4vU8Q2HjXKQs9IEst0hzZ7ymDHe2fOMPPWHOrHMZl0EmquyhJgskSnrHEpUYGIzLER1cf92pA/OTjVcomjSISbqq/eE+DgzKid+Ss0TQPj54tWibIFx7SWXxHPDxh7CIEIoe36jr1cFGzA0cqJ5Sd7I4dNXZxAR7LreBD/8JEHPd+1tnjtdJdgFq7ZhsD/3oJnvH8qgdZRuiiz3bXZcGSwGUVNivxSsaB4HjHksxyaGX89gnwTVY6tKZnvBwgiT1rPF0tlNIsnoOJxnCA15/f2JTDxC4B3qG+xZg4d+4kbSQyAD4lgRAs6GwqRQIDAQABAoIBABs9Dwxy599kCXsZ44OdARgFMsFLfN6KwFotaPiu75/uQVcMiBHz/ylI/r+5sSK9b5KXpBgBqReEjZtBm5/0tzWcWYwgRcB7RcYN4V7g0HylGfsFDlU2Yq5JUEjBw4QTburyXIS3TlbHCHN8x+vPLz1h1+yo6afnzqo6wqcE2aPN4RH4NdOPsl9EKBUg7rsHi+HtycYxF3VJF5TRBeSAhFBmy6kPmcLLpPSyJGR/uk2V7MloGulewVU9B3y+TcXxsiEvvmr+42n0VNJVMPZcwMZiy3Ws9w7oxmjOfEgNQ2108cIMnPXET9Ezz8Iaevljbhm5vtqOXqr8OZyyEm/IuskCgYEA0wA/FfVTmqX3bAXTMLRg5/bCI9NI+lGwciJjcqYYQVZSrkrG6rgdpiFc2ZAV/5HBFJ97crxAap5CkyOhdMDkKMCsyDdV7hM62tS4J7Vmsyb6YxafRTfs0jhAioNIz20vUBpTLGOc4QoSToC4RDvwqAzBTcMb77EzV6GLVV0uPssCgYEAx1jBB1G4YhGMo2bv1xNs8Ydd4YR5PjNO30ETVhrn5gkMhgc/xSp32k2/0isP7b8cS+y5ClHMOicZ17G6sXF3HkYWD4Jaue5EMACy+6YwWOGkU+ROJNud3U+6z43JLx+sr5PCANvoL+HoB1yaRGTXGBitnj+IJM7PISs5pol8iS8CgYEA0GjB5xJ2DZ44kL4AJ29C+FtGztP2lSjyuwk0aR2df4ugBv9dEqHgxyLU7x/eWpzAtXoBGQbQKX9ACs16wDN2KLqG7wuZGJpt24+YhcArPHEXh5/kmR3wEIP3W9jopdkWjmwyEvohDjZAdsG1P9Bkl9hhZkl84neIWtn5IcvzzZkCgYBsbESIs5TimgLxOOKIC0O81lBkgUXkY8mpOd7HfVjVz+Qk3bp8hY2siY8kQ1GlkMVWMkmuaDD5DB1NKJiPPFR6fcov40lvST2DEk5G+uve29Mh4dHy0BQ7s8q6araaz9J/qJDjILhXmro1jtNFEce/jmSX5pwo0ObtdnIjtzGp9wKBgFHIN2K4jW3DixOam1ssvtbbX8nVuHsQn0dJ8QmDFgAlstBqbXmu2P8I/esW4PRAdJPiOCEnnpXiTwrnHeD29xNUxzrsV1SbbeBhZ86U+WuVGRx46DJWIa56b1LjGWVSeIckLFFaIn9s0pF1RaUnz0Unjjdzr1rwAij1vrAGw93C" ],
+        "certificate" : [ "MIICpTCCAY0CBgGUGPLIATANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAtXZWJJbnNpZ2h0czAeFw0yNDEyMzAxOTAwNTFaFw0zNDEyMzAxOTAyMzFaMBYxFDASBgNVBAMMC1dlYkluc2lnaHRzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApE5YOPkspnnCv5CgSujw5Z3jR+s4vU8Q2HjXKQs9IEst0hzZ7ymDHe2fOMPPWHOrHMZl0EmquyhJgskSnrHEpUYGIzLER1cf92pA/OTjVcomjSISbqq/eE+DgzKid+Ss0TQPj54tWibIFx7SWXxHPDxh7CIEIoe36jr1cFGzA0cqJ5Sd7I4dNXZxAR7LreBD/8JEHPd+1tnjtdJdgFq7ZhsD/3oJnvH8qgdZRuiiz3bXZcGSwGUVNivxSsaB4HjHksxyaGX89gnwTVY6tKZnvBwgiT1rPF0tlNIsnoOJxnCA15/f2JTDxC4B3qG+xZg4d+4kbSQyAD4lgRAs6GwqRQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBH26GaceVJUTV5WsbLdM4BDTz6g9QGc9fz2mjb484COKdwtMouOmLmUmZlWBBjKlRg+Qp4mCRm16PoEjqUXMgDiVgAW+oPaJ5g5xHeaXYGdtuV8vfJDx+WIFp6GpgFUid9dgJO8D4r6CuFKa769WvEeISn6MrSBbzOcXZmA63hd96cWaTp5w9lUKjzOiImfzB5EUO1GhcFqDL43zWA2gEtODrx46sL1hY687Y4zqUaONvWPsHE7S1yz2+MQjV3cq1ghRS/M6lV2gDZcEQcfATEH/z4afQ9L0AeQ+EgsnKPTzDxkjQ7zvuLoDI3u6z4CwwSpaR9GC5bFt29oN3jPTTt" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "bbb5ca0a-05d7-457f-8274-749eb5255451",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAmAKa0w+zwxUEQCW2jjGZY6rJ4zB7wINWTgf1oS8HgKQ+DgzEvJLxNlXU5RN7gyg2ChjSUYmOunb+WFQL3tmHytOQA6liGL6G2OdFzUL6+UGuwVjUGeRc1aP7Cj7IY+u8ZFBjXFXO5QOxKEVa1/L7WKgrN1mkxsMH7ru7d7kwC/av/Ub6dWui3PpvMcsFEvp5VuhFngzhCjHWI9hqdYhLJJgtZNRkR0UuNMKs/hGkffhwj32ZZV3iEHeFXjdB2dkrIKrVp31jHjTZ/+0Q0hb2YvJ88LL9RuMDU/vJN+sWjUJwx7qy4I80LL8gaP3Ad9ZAetV/7hXstLdUYL8XoYO8IQIDAQABAoIBAAlSmj2OMvoolHrSqqA3OS8RpGbDQckMGljtcrUQoKcqa4aKZe54HJm2feNmudEmFYUHrK5vf0oUTi5gnocWVEEDj0uKMd1Oog/fbzp9fHhDp6dtU+TFSqRCSv0qiI5dliTuK98tLA6Dlsk00l4i0CN0fOIHehbukyf4ajDs3J4pygrG3RlNsYOTpgfn5BDsIx9s9rEGm08lLHrbGAFqIp8uNkp+MENe6ZGBpLDqQSrR88BZND+nHDueonLUqJ9LVRMG1qvexsOoWJIuHG0cM9gU8ctsWdcfQB8wlP37esQ8KY/OO7UPNB1GPTSiV5s6x3q5m3jr+d8/ugiYatQxfFkCgYEA0rdfq4v/23j98PVFXcdAlSzGfwChOWgVOJi9C9HVrMW0Fgn91vGUe/9EIBkQ3SQb/C54n0nOE7DmaLL2geO209WgDEdKP4LSLUNLTehBN1C0hTleqZlkQtF/P5pYxpUS4yJN0BOI2k/Wzg/sWiGnnuRJLUQOUFx8HLr/UW3mTtsCgYEAuK1+hXbPQaQdK8MhO+bISGbC6NbqYYC00jGVOLtBPolMn1s7b0zTaYfglMycxtujDYSrLOwA2IR+2WbRyl4VJ4sqGZUvMTWenaEoia67Ja60ZoRdzNqP6X/Z+80DbKYtD59oq7siC8nR3xgsWPI0EEYvMUF7etl3ju168D30m7MCgYBwBY6162qtKgiOxkYHUftykug/8nzDwSKvAPxXwUlAXaacpNkvISVYOl/kVI8TkbPTAH2d6SXGcCA9/w5wBThYK9S3UlsVop3L9F+fXl71YlFmFhbOQT79CtUEYjDZ+bydxcnqWchCj3lZ+Tsku4maPjDtAKY/cLuGpp8/khaDSwKBgEIgxbwupdogVN21unHDmpXqTgKn6jdNqfHWFVPCIYOuEETDm02oWc9g+zbs6Xp/bSxLBCxKuabOEsnv+lEXTUXinAmbFNHvHEPfUC+05IiCvVA0N45B+OQohrqWV5KREnOUphtQH8nO05qqAj87Qw9MwltF0lxUAG6qdKoP1UXnAoGBAL22+doTVVbamwn9QeMMje59fObHWxNqeA0eeyF6kNePka2Gpa24Nk5yQgyz+FEWB9vgKT5H0ZpRO1m77VccixDejCDWYlbdFR1/cfU+VTL4y4crVF1lMeO3kZjaUdvFjxKA8+KpKan3cyNuCICYWPRNlIk2AyA5KASAvKc7qJEv" ],
+        "certificate" : [ "MIICpTCCAY0CBgGUGPLIuzANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAtXZWJJbnNpZ2h0czAeFw0yNDEyMzAxOTAwNTFaFw0zNDEyMzAxOTAyMzFaMBYxFDASBgNVBAMMC1dlYkluc2lnaHRzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmAKa0w+zwxUEQCW2jjGZY6rJ4zB7wINWTgf1oS8HgKQ+DgzEvJLxNlXU5RN7gyg2ChjSUYmOunb+WFQL3tmHytOQA6liGL6G2OdFzUL6+UGuwVjUGeRc1aP7Cj7IY+u8ZFBjXFXO5QOxKEVa1/L7WKgrN1mkxsMH7ru7d7kwC/av/Ub6dWui3PpvMcsFEvp5VuhFngzhCjHWI9hqdYhLJJgtZNRkR0UuNMKs/hGkffhwj32ZZV3iEHeFXjdB2dkrIKrVp31jHjTZ/+0Q0hb2YvJ88LL9RuMDU/vJN+sWjUJwx7qy4I80LL8gaP3Ad9ZAetV/7hXstLdUYL8XoYO8IQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCAhPnUikc+R32MDozwGZHwNHmgtyFp6CVH+5+goUdPXx6B28G7dYrPrsZoNE2kIJI5PB4YXtQ9b3q5mOm193Euo0FWJBZP/wcbsEmjT08TTwYbS0SrCeTMGGAwNm3caAvHVMc2fuHql/lRnRLKg1eWGB7rvS/fF1Qmy/7AP18Po3BD7KXCSpGGlurXHVDjDsjMYmgbThxuEG7KClgHxuHRbKuEBlXWCBKsFqz64USHC6eXbCE+lqH/tQ+cJNhy3CTkXAxBsIYpex+92g84xocUQMcRSs8oBPMydxduUEPUJIUwP17rnBlOoVshpLvzNPByRUkh8eJUIIq/N2rgOfoH" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "bfbd9a16-0897-498f-acb0-0497bdf510d4",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "1bf6b834-e758-4318-8b51-c636e5ec29af" ],
+        "secret" : [ "wEmVqXJXrS0grxSHxiwjOg" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ "" ],
+  "authenticationFlows" : [ {
+    "id" : "6eb84b3d-9456-4314-936b-9a85af38d807",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "1c1c8b26-0301-49b9-9e63-6c6f5dbe80f1",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6365e270-7512-4c81-b23f-a4e0a34e9a6d",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6acef456-d113-43b4-b906-5fb64b1b7872",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "21ba1d39-13e2-45c4-933c-34402d646dee",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9633bb97-81bf-4ff7-ac1d-71106e3415d4",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "5a189afc-bb64-48f8-a8a9-e04c0024d3c5",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8a78a55c-db20-49dc-89f2-a456656f7f94",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "4be57c1d-cb3d-4aef-b38c-3b8d1aadde98",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0187ae01-52c9-4c59-9455-40efb6a27f08",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "26d2d930-17f5-4241-95ff-b402a6d85fb3",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "de750c92-7bae-4be2-b584-4f44993ef4d4",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f17b79bc-5146-4685-98c6-fa95f5bc6bbd",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3b6cbbae-ff59-4d3c-bfc0-84d0d1b41efa",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "597ee081-7e95-42f3-9bb9-3f0b743884fb",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "bf53e41e-b559-4df8-beaf-0c67361d384d",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "991c36fc-14ef-4aa1-9d3d-fc35f0b52552",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a9882e35-9cde-400f-8e57-bf9157db3854",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "5e0b8117-200b-42d6-857a-6584a8ae1aa9",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "ebd22733-4a39-4d75-89a4-f88f27a5585e",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "23.0.6",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/web-insights-docker/keycloak/imports/WebInsights-users-0.json
+++ b/web-insights-docker/keycloak/imports/WebInsights-users-0.json
@@ -1,0 +1,27 @@
+{
+  "realm" : "WebInsights",
+  "users" : [ {
+    "id" : "7290b4a1-056c-47e2-814a-e588aaa8e899",
+    "createdTimestamp" : 1735585526286,
+    "username" : "insider",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "insider name",
+    "lastName" : "insider last name",
+    "email" : "d.test@test.com",
+    "credentials" : [ {
+      "id" : "3659ceea-c5e4-4373-aee4-5f8190459ea4",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1735585566436,
+      "secretData" : "{\"value\":\"mFFMpDILwYEYfsHNfwnx+1Py8AzFOZLXStq5xxMjLoc=\",\"salt\":\"byLk1M3fKAZnLNso1vfX1g==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-webinsights" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ]
+}


### PR DESCRIPTION
# Why
Import and export realm with user to make possible to setup fresh instance of keycloak which will helps in the bdd tests and run app with default state.
# What
1. Create bash files for import and export realm with user.
2. Add `volumes` property for keycloak image and add `--import-realm` flag do import realm and user when we start docker container.