### PR TITLE
refactor: do not use HostBinding decorator

### DIFF
--- a/web-insights-web/src/app/shared/ui/directives/full-width/full-width.directive.ts
+++ b/web-insights-web/src/app/shared/ui/directives/full-width/full-width.directive.ts
@@ -1,13 +1,12 @@
-import { Directive, HostBinding, Input } from '@angular/core';
+import { Directive, Input } from '@angular/core';
 
 @Directive({
   selector: '[wiFullWidth]',
   standalone: true,
+  host: {
+    '[class.w-full]': 'wiFullWidth',
+  },
 })
 export class FullWidthDirective {
   @Input() wiFullWidth = false;
-
-  @HostBinding('class.w-full') get isFullWidth(): boolean {
-    return this.wiFullWidth;
-  }
 }


### PR DESCRIPTION
This pull request refactors the `FullWidthDirective` to simplify its implementation by replacing the `@HostBinding` decorator with a `host` metadata property.
